### PR TITLE
Ticket 5513: Use EPICS standard build of google test

### DIFF
--- a/Keithley2001Sup/src/Makefile
+++ b/Keithley2001Sup/src/Makefile
@@ -30,13 +30,11 @@ ifeq ($(findstring 10.0,$(VCVERSION)),)
 
 SRC_DIRS += $(TOP)/Keithley2001Sup/tests
 
-TESTPROD_HOST += runner
-USR_CPPFLAGS += -I$(GTEST)/googletest/include 
-runner_SRCS += run_all_tests.cc
+GTESTPROD_HOST += runner
 runner_SRCS +=  buffer_parsing_utils.cpp input_parsing_tests.cc output_setting_tests.cc
 runner_SRCS +=  buffer_parsing_tests.cc
 runner_SRCS += sequencer_utils_tests.cc sequencer_utils.cpp
-runner_LIBS += gtest
+GTESTS += runner
 endif
 
 #----------------------------------------------------
@@ -46,3 +44,4 @@ endif
 include $(TOP)/configure/RULES
 #----------------------------------------
 #  ADD RULES AFTER THIS LINE
+include $(GTEST)/cfg/compat.RULES_BUILD

--- a/Keithley2001Sup/tests/run_all_tests.cc
+++ b/Keithley2001Sup/tests/run_all_tests.cc
@@ -1,6 +1,0 @@
-#include "gtest/gtest.h"
-
-int main(int argc, char **argv) {
-        ::testing::InitGoogleTest( &argc, argv );
-        return RUN_ALL_TESTS();
-    }

--- a/Makefile
+++ b/Makefile
@@ -31,14 +31,5 @@ $(foreach dir, $(filter %Top, $(DIRS)), \
 iocBoot_DEPEND_DIRS += $(filter %App,$(DIRS))
 
 # Add any additional dependency rules here:
-
-TEST_RUNNER = $(TOP)/Keithley2001Sup/src/O.$(EPICS_HOST_ARCH)/runner
-
 include $(TOP)/configure/RULES_TOP
-
-.PHONY: test
-test:
-ifneq ($(wildcard $(TEST_RUNNER)*),)
-	$(TEST_RUNNER) --gtest_output=xml:$(TOP)/test-reports/TEST-Keithley2001.xml
-endif
 


### PR DESCRIPTION
See https://github.com/ISISComputingGroup/IBEX/issues/5513

To test:

* Run `make runtests` in this submodule and confirm tests run